### PR TITLE
Fix Criteria::orderByField failue

### DIFF
--- a/App/Config/Initializer/Console.php
+++ b/App/Config/Initializer/Console.php
@@ -31,6 +31,7 @@
 namespace App\Config\Initializer;
 
 use Samurai\Samurai\Application as SamuraiApplication;
+use Samurai\Samurai\Component\Console\Client\ConsoleClient;
 use Samurai\Samurai\Component\Core\Initializer;
 use Samurai\Samurai\Component\Console\Client\MultipleClient;
 use Samurai\Samurai\Component\Console\Client\BrowserClient;

--- a/Samurai/Onikiri/Criteria/Criteria.php
+++ b/Samurai/Onikiri/Criteria/Criteria.php
@@ -267,6 +267,8 @@ class Criteria
      */
     public function orderByField($column, array $params = [])
     {
+        if (count($params) <= 0) return $this;
+
         $this->order->addByField($column, $params);
         return $this;
     }

--- a/Samurai/Onikiri/Spec/Samurai/Onikiri/Criteria/CriteriaSpec.php
+++ b/Samurai/Onikiri/Spec/Samurai/Onikiri/Criteria/CriteriaSpec.php
@@ -147,6 +147,12 @@ class CriteriaSpec extends PHPSpecContext
         $this->getParams()->shouldBe(['category1', 'category2', 'category3']);
     }
 
+    public function it_is_not_order_by_field_when_empty_params()
+    {
+        $this->orderByField('category', []);
+        $this->toSQL()->shouldBe('SELECT * FROM foo WHERE 1');
+    }
+
     public function it_is_limit_condition()
     {
         $this->limit(10);


### PR DESCRIPTION
when argument is empty array , Criteria::orderByField() takes SQL syntax error

``` sql
SELECT * FROM table1 ORDER BY (`field`, )
```
